### PR TITLE
validate uncommitted changes

### DIFF
--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1211,8 +1211,8 @@ class P4ConnectionManager:
 
     def _connect_get_last_change_list(self):
         client_info = self.p4.run("client", "-o")[0]
-        client = client_info["Client"]
-        cmd = ["changes", "-s", "submitted", "-m", 1, "-c", client]
+        client_stream = client_info["Stream"]
+        cmd = ["changes", "-s", "submitted", "-m", 1, f"{client_stream}/..."]
         change_list = self._connect_run_command(*cmd)
         if not change_list:
             return

--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1834,6 +1834,16 @@ class P4ConnectionManager:
 
         return int(result[0]["change"])
 
+    def _connect_submit_default_changelist(self, change_description: str) -> int | None:
+        default_cl_cmd = ["change", "-o"]
+        default_cl = self.p4.run(*default_cl_cmd)[0]
+        default_cl["Description"] = change_description
+        result = self.p4.run_submit(default_cl)
+        if not result:
+            return None
+
+        return int(result[0]["change"])
+
     def _connect_sync(self, path):
         """
         Synonym for get_latest

--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1200,6 +1200,15 @@ class P4ConnectionManager:
         # returns list as _process_result_ breaks dictionary
         return change_list
 
+    def _connect_get_uncommitted_changes(self):
+        client_spec = self._connect_run_command("client", "-o")[0]
+        cmd = ["changes", "-s", "pending", "-c", client_spec["Client"]]
+        changes = self._connect_run_command(*cmd)
+
+        if default_changes := self._connect_run_command("opened", "-c", "default"):
+            changes.append(default_changes)
+        return changes
+
     def _connect_get_last_change_list(self):
         client_info = self.p4.run("client", "-o")[0]
         client = client_info["Client"]

--- a/client/version_control/backends/perforce/backend.py
+++ b/client/version_control/backends/perforce/backend.py
@@ -100,6 +100,11 @@ class VersionControlPerforce(abstract.VersionControl):
         return api.get_changes(stream=stream)
 
     @staticmethod
+    def get_uncommitted_changes():
+        # type: (None) -> (list(dict)) | None
+        return api.get_uncommitted_changes()
+
+    @staticmethod
     def get_existing_change_list(comment):
         # type: (str) -> dict[str, Any] | None
         return api.get_existing_change_list(comment)

--- a/client/version_control/backends/perforce/backend.py
+++ b/client/version_control/backends/perforce/backend.py
@@ -142,6 +142,11 @@ class VersionControlPerforce(abstract.VersionControl):
         return api.submit_change_list(comment)
 
     @staticmethod
+    def submit_default_changelist(comment):
+        # type: (str) -> int | None
+        return api.submit_default_changelist(comment)
+
+    @staticmethod
     def update_change_list_description(comment, new_comment):
         # type: (str, str) -> bool
         return api.update_change_list_description(comment, new_comment)

--- a/client/version_control/backends/perforce/rest_routes.py
+++ b/client/version_control/backends/perforce/rest_routes.py
@@ -199,6 +199,18 @@ class SubmitChangelist(PerforceRestApiEndpoint):
         )
 
 
+class Revert(PerforceRestApiEndpoint):
+    async def post(self, request) -> Response:
+        log.debug("Revert called")
+        content = await request.json()
+
+        result = VersionControlPerforce.revert(content["path"])
+        return Response(
+            status=200,
+            body=self.encode(result),
+            content_type="application/json"
+        )
+
 class ExistsOnServer(PerforceRestApiEndpoint):
     """Returns information about file on 'path'."""
     async def post(self, request) -> Response:

--- a/client/version_control/backends/perforce/rest_routes.py
+++ b/client/version_control/backends/perforce/rest_routes.py
@@ -157,6 +157,19 @@ class GetChanges(PerforceRestApiEndpoint):
             content_type="application/json"
         )
 
+class GetUncommittedChanges(PerforceRestApiEndpoint):
+    """Returns list of uncomitted changes."""
+    async def post(self, request) -> Response:
+        log.debug("GetUncommittedChanges called")
+        content = await request.json()
+
+        result = VersionControlPerforce.get_uncommitted_changes()
+        return Response(
+            status=200,
+            body=self.encode(result),
+            content_type="application/json"
+        )
+
 
 class GetLastChangelist(PerforceRestApiEndpoint):
     """Returns list of dict with project info (id, name)."""

--- a/client/version_control/backends/perforce/rest_routes.py
+++ b/client/version_control/backends/perforce/rest_routes.py
@@ -199,6 +199,20 @@ class SubmitChangelist(PerforceRestApiEndpoint):
         )
 
 
+class SubmitDefaultChangelist(PerforceRestApiEndpoint):
+    """Returns list of dict with project info (id, name)."""
+    async def post(self, request) -> Response:
+        log.debug("SubmitChangelist called")
+        content = await request.json()
+
+        result = VersionControlPerforce.submit_default_changelist(content["comment"])
+        return Response(
+            status=200,
+            body=self.encode(result),
+            content_type="application/json"
+        )
+
+
 class Revert(PerforceRestApiEndpoint):
     async def post(self, request) -> Response:
         log.debug("Revert called")

--- a/client/version_control/changes_viewer/model.py
+++ b/client/version_control/changes_viewer/model.py
@@ -31,6 +31,9 @@ class ChangesModel(QtGui.QStandardItemModel):
         self.removeRows(0, self.rowCount())  # Clear existing data
         changes = self._controller.get_changes()
 
+        if not isinstance(changes, list):
+            changes = [changes]
+
         for change in changes:
             date_time = datetime.fromtimestamp(int(change["time"]))
             date_string = date_time.strftime("%Y%m%dT%H%M%SZ")

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -144,6 +144,6 @@ class UncommittedChangesRepairer(ErrorMessageBox):
             return
 
         changelist_message = self.mb_submit_message.toPlainText()
-        changelist_message = f"[AYON Publish Submission]\t{changelist_message}"
+        changelist_message = f"[PRE PUBLISH] {changelist_message}"
         PerforceRestStub.submit_default_changelist(changelist_message)
         self.accept()

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -1,7 +1,9 @@
 import os
 
 import pyblish.api
+from qtpy import QtWidgets
 
+from ayon_core.tools.utils import ErrorMessageBox
 from ayon_core.pipeline.publish import (
     ValidateContentsOrder,
     RepairAction,
@@ -24,10 +26,82 @@ class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
         if uncommitted_changes:
             for change in uncommitted_changes:
                 self.log.error(f"Uncommitted change: {change}")
+            instance.data["uncommitted_changes"] = uncommitted_changes
             raise PublishValidationError("Workspace has uncommitted changes! Please commit or revert before publish.")
         # # TODO: check for stream updates
 
     @classmethod
     def repair(cls, instance):
-        # TODO: present little dialog to user to commit or revert
+        UncommittedChangesRepairer(instance.data["uncommitted_changes"]).exec_()
+
+
+class UncommittedChangesRepairer(ErrorMessageBox):
+
+    mb_submit_message: QtWidgets.QMessageBox = None
+    lw_uncommitted_changes: QtWidgets.QListWidget = None
+
+    def __init__(self, uncommitted_changes: list):
+        self.title = "Pending Files in Changelist"
+        self.parent = QtWidgets.QApplication.activeWindow()
+        self.uncommitted_changes = uncommitted_changes
+        super().__init__(self.title, self.parent)
+
+    def _create_content(self, content_layout) -> None:
+        label = QtWidgets.QLabel(
+            "You have pending files in your changelist.\nPlease revert, shelve or submit them before launching Unreal Engine again."
+        )
+        content_layout.addWidget(label)
+
+        self.lw_uncommitted_changes = QtWidgets.QListWidget()
+        for change in self.uncommitted_changes:
+            self.lw_uncommitted_changes.addItem(f"[{change['action'].upper()}]\t{change['clientFile']}")
+
+        # allow multiple selection
+        self.lw_uncommitted_changes.setSelectionMode(
+            QtWidgets.QAbstractItemView.MultiSelection
+        )
+        content_layout.addWidget(self.lw_uncommitted_changes)
+
+        self.mb_submit_message = QtWidgets.QPlainTextEdit()
+        self.mb_submit_message.setPlaceholderText("Enter a message for the submit")
+
+        content_layout.addWidget(self.mb_submit_message)
+        btn_revert_selected = QtWidgets.QPushButton("Revert Selected")
+        btn_revert = QtWidgets.QPushButton("Revert All")
+        btn_submit = QtWidgets.QPushButton("Submit")
+        btn_revert.clicked.connect(self.on_revert)
+        btn_revert_selected.clicked.connect(self.on_revert_selected)
+        btn_submit.clicked.connect(self.on_submit)
+        content_layout.addWidget(btn_revert_selected)
+        content_layout.addWidget(btn_revert)
+        content_layout.addWidget(btn_submit)
+
+    def on_revert_selected(self):
+        if self.lw_uncommitted_changes.selectedItems():
+            for item in self.lw_uncommitted_changes.selectedItems():
+                self.revert(item.text())
+                # remove item from list
+                self.lw_uncommitted_changes.takeItem(self.lw_uncommitted_changes.row(item))
+
+        if self.lw_uncommitted_changes.count() == 0:
+            self.accept()
+
+    def on_revert(self):
+        self.revert("//...")
+        self.lw_uncommitted_changes.clear()
+        self.accept()
+
+    def revert(self, file):
+        # TODO: implement
         pass
+
+    def on_submit(self):
+        if self.mb_submit_message.toPlainText() == "":
+            errorbox = GenericErrorBox(
+                "Submit Error", "Please enter a message for the submit"
+            )
+            errorbox.exec_()
+            return
+
+        # TODO: implement default changelist submission
+        self.accept()

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -1,11 +1,14 @@
 import os
 
 import pyblish.api
-from ayon_core.pipeline.publish import ValidateContentsOrder
-from ayon_core.pipeline import PublishXmlValidationError
+
+from ayon_core.pipeline.publish import (
+    ValidateContentsOrder,
+    RepairAction,
+    PublishValidationError,
+)
 
 from version_control.rest.perforce.rest_stub import PerforceRestStub
-
 
 class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
     """Validates if local workspace has no uncomitted changes."""
@@ -14,9 +17,17 @@ class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
     label = "Validate P4 workspace is clean"
     families = ["changelist_metadata"]
     targets = ["local"]
+    actions = [RepairAction]
 
     def process(self, instance):
         uncommitted_changes = PerforceRestStub.get_uncommitted_changes()
         if uncommitted_changes:
-            raise Exception("Workspace has uncommitted changes! Please commit or revert before publish.")
+            for change in uncommitted_changes:
+                self.log.error(f"Uncommitted change: {change}")
+            raise PublishValidationError("Workspace has uncommitted changes! Please commit or revert before publish.")
         # # TODO: check for stream updates
+
+    @classmethod
+    def repair(cls, instance):
+        # TODO: present little dialog to user to commit or revert
+        pass

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -83,6 +83,7 @@ class UncommittedChangesRepairer(ErrorMessageBox):
         self.workspace_dir = workspace_dir
         self.workspace_name = workspace_name
         super().__init__(self.title, self.parent)
+        self.resize(800, 600)
 
     def _create_content(self, content_layout) -> None:
         label = QtWidgets.QLabel(

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -32,8 +32,33 @@ class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
 
     @classmethod
     def repair(cls, instance):
-        UncommittedChangesRepairer(instance.data["uncommitted_changes"]).exec_()
+class ChangesSelectionListModel(QtCore.QAbstractListModel):
+    def __init__(self, data, parent=None):
+        super().__init__(parent)
+        self._data = data
 
+    def rowCount(self, parent):
+        return len(self._data)
+
+    def get_index(self, value):
+        for idx, val in enumerate(self._data):
+            if val == value:
+                return idx
+        return None
+
+    def data(self, index, role):
+        if isinstance(index, QtCore.QModelIndex):
+            index = index.row()
+        if role == QtCore.Qt.DisplayRole:
+            return f"[{self._data[index]['action']}]\t{self._data[index]['clientFile']}"
+        if role == QtCore.Qt.UserRole:
+            return self._data[index]
+
+    def removeRows(self, row, count, parent=QtCore.QModelIndex()):
+        self.beginRemoveRows(parent, row, row + count - 1)
+        del self._data[row:row + count]
+        self.endRemoveRows()
+        return True
 
 class UncommittedChangesRepairer(ErrorMessageBox):
 
@@ -52,15 +77,16 @@ class UncommittedChangesRepairer(ErrorMessageBox):
         )
         content_layout.addWidget(label)
 
-        self.lw_uncommitted_changes = QtWidgets.QListWidget()
-        for change in self.uncommitted_changes:
-            self.lw_uncommitted_changes.addItem(f"[{change['action'].upper()}]\t{change['clientFile']}")
+        self.lv_uncommitted_changes = QtWidgets.QListView()
+        self.lv_uncommitted_changes.setAlternatingRowColors(True)
 
-        # allow multiple selection
-        self.lw_uncommitted_changes.setSelectionMode(
+        self.lv_uncommitted_changes.setModel(
+            ChangesSelectionListModel(self.uncommitted_changes)
+        )
+        self.lv_uncommitted_changes.setSelectionMode(
             QtWidgets.QAbstractItemView.MultiSelection
         )
-        content_layout.addWidget(self.lw_uncommitted_changes)
+        content_layout.addWidget(self.lv_uncommitted_changes)
 
         self.mb_submit_message = QtWidgets.QPlainTextEdit()
         self.mb_submit_message.setPlaceholderText("Enter a message for the submit")

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -1,7 +1,9 @@
+from copy import deepcopy
 import os
+from pathlib import Path
 
 import pyblish.api
-from qtpy import QtWidgets
+from qtpy import QtCore, QtWidgets
 
 from ayon_core.tools.utils import ErrorMessageBox
 from ayon_core.pipeline.publish import (
@@ -11,6 +13,7 @@ from ayon_core.pipeline.publish import (
 )
 
 from version_control.rest.perforce.rest_stub import PerforceRestStub
+
 
 class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
     """Validates if local workspace has no uncomitted changes."""
@@ -27,11 +30,20 @@ class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
             for change in uncommitted_changes:
                 self.log.error(f"Uncommitted change: {change}")
             instance.data["uncommitted_changes"] = uncommitted_changes
-            raise PublishValidationError("Workspace has uncommitted changes! Please commit or revert before publish.")
+            raise PublishValidationError(
+                "Workspace has uncommitted changes! Please commit or revert before publish."
+            )
         # # TODO: check for stream updates
 
     @classmethod
     def repair(cls, instance):
+        UncommittedChangesRepairer(
+            uncommitted_changes=instance.data["uncommitted_changes"],
+            workspace_dir=instance.context.data["version_control"]["workspace_dir"],
+            workspace_name=instance.context.data["version_control"]["workspace_name"]
+        ).exec_()
+
+
 class ChangesSelectionListModel(QtCore.QAbstractListModel):
     def __init__(self, data, parent=None):
         super().__init__(parent)
@@ -61,14 +73,15 @@ class ChangesSelectionListModel(QtCore.QAbstractListModel):
         return True
 
 class UncommittedChangesRepairer(ErrorMessageBox):
-
     mb_submit_message: QtWidgets.QMessageBox = None
-    lw_uncommitted_changes: QtWidgets.QListWidget = None
+    lv_uncommitted_changes: QtWidgets.QListView = None
 
-    def __init__(self, uncommitted_changes: list):
+    def __init__(self, uncommitted_changes: list, workspace_dir: str, workspace_name: str):
         self.title = "Pending Files in Changelist"
         self.parent = QtWidgets.QApplication.activeWindow()
         self.uncommitted_changes = uncommitted_changes
+        self.workspace_dir = workspace_dir
+        self.workspace_name = workspace_name
         super().__init__(self.title, self.parent)
 
     def _create_content(self, content_layout) -> None:
@@ -103,13 +116,20 @@ class UncommittedChangesRepairer(ErrorMessageBox):
         content_layout.addWidget(btn_submit)
 
     def on_revert_selected(self):
-        if self.lw_uncommitted_changes.selectedItems():
-            for item in self.lw_uncommitted_changes.selectedItems():
-                self.revert(item.text())
-                # remove item from list
-                self.lw_uncommitted_changes.takeItem(self.lw_uncommitted_changes.row(item))
+        selection = self.lv_uncommitted_changes.selectedIndexes()
+        for index in selection:
+            # we need to buil;d an absolute local path
+            # it seems p4 revert doesn't like depot or client syntax?!
+            client_file = deepcopy(index.data(QtCore.Qt.UserRole)["clientFile"])
+            client_file = client_file.replace("//", "")
+            client_file = client_file.replace(str(self.workspace_name), self.workspace_dir)
+            client_file = Path(client_file)
+            file_to_revert = self.workspace_dir / client_file
 
-        if self.lw_uncommitted_changes.count() == 0:
+            PerforceRestStub.revert(path=file_to_revert.as_posix())
+            self.lv_uncommitted_changes.model().removeRow(index.row())
+
+        if self.lv_uncommitted_changes.model().rowCount(QtCore.QModelIndex()) == 0:
             self.accept()
 
     def on_revert(self):

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -106,13 +106,10 @@ class UncommittedChangesRepairer(ErrorMessageBox):
 
         content_layout.addWidget(self.mb_submit_message)
         btn_revert_selected = QtWidgets.QPushButton("Revert Selected")
-        btn_revert = QtWidgets.QPushButton("Revert All")
         btn_submit = QtWidgets.QPushButton("Submit")
-        btn_revert.clicked.connect(self.on_revert)
         btn_revert_selected.clicked.connect(self.on_revert_selected)
         btn_submit.clicked.connect(self.on_submit)
         content_layout.addWidget(btn_revert_selected)
-        content_layout.addWidget(btn_revert)
         content_layout.addWidget(btn_submit)
 
     def on_revert_selected(self):
@@ -132,14 +129,6 @@ class UncommittedChangesRepairer(ErrorMessageBox):
         if self.lv_uncommitted_changes.model().rowCount(QtCore.QModelIndex()) == 0:
             self.accept()
 
-    def on_revert(self):
-        self.revert("//...")
-        self.lw_uncommitted_changes.clear()
-        self.accept()
-
-    def revert(self, file):
-        # TODO: implement
-        pass
 
     def on_submit(self):
         if self.mb_submit_message.toPlainText() == "":

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -1,0 +1,22 @@
+import os
+
+import pyblish.api
+from ayon_core.pipeline.publish import ValidateContentsOrder
+from ayon_core.pipeline import PublishXmlValidationError
+
+from version_control.rest.perforce.rest_stub import PerforceRestStub
+
+
+class ValidateWorkspaceIsClean(pyblish.api.InstancePlugin):
+    """Validates if local workspace has no uncomitted changes."""
+
+    order = ValidateContentsOrder + 0.01
+    label = "Validate P4 workspace is clean"
+    families = ["changelist_metadata"]
+    targets = ["local"]
+
+    def process(self, instance):
+        uncommitted_changes = PerforceRestStub.get_uncommitted_changes()
+        if uncommitted_changes:
+            raise Exception("Workspace has uncommitted changes! Please commit or revert before publish.")
+        # # TODO: check for stream updates

--- a/client/version_control/plugins/publish/validate_workspace_is_clean.py
+++ b/client/version_control/plugins/publish/validate_workspace_is_clean.py
@@ -133,11 +133,17 @@ class UncommittedChangesRepairer(ErrorMessageBox):
 
     def on_submit(self):
         if self.mb_submit_message.toPlainText() == "":
-            errorbox = GenericErrorBox(
-                "Submit Error", "Please enter a message for the submit"
-            )
-            errorbox.exec_()
+            msg_box = QtWidgets.QMessageBox()
+            msg_box.setIcon(QtWidgets.QMessageBox.Critical)
+            msg_box.setWindowTitle("No commit message found")
+            msg_box.setText("Please enter a message for the submit")
+            msg_box.setStandardButtons(QtWidgets.QMessageBox.Ok)
+            msg_box.setWindowModality(QtCore.Qt.ApplicationModal)
+            msg_box.setWindowFlags(msg_box.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
+            msg_box.exec_()
             return
 
-        # TODO: implement default changelist submission
+        changelist_message = self.mb_submit_message.toPlainText()
+        changelist_message = f"[AYON Publish Submission]\t{changelist_message}"
+        PerforceRestStub.submit_default_changelist(changelist_message)
         self.accept()

--- a/client/version_control/rest/perforce/rest_api.py
+++ b/client/version_control/rest/perforce/rest_api.py
@@ -77,6 +77,13 @@ class PerforceModuleRestAPI:
             get_changes.dispatch
         )
 
+        get_uncommitted_changes = rest_routes.GetUncommittedChanges()
+        self.server_manager.add_route(
+            "POST",
+            self.prefix + "/get_uncommitted_changes",
+            get_uncommitted_changes.dispatch
+        )
+
         get_last_change_list = rest_routes.GetLastChangelist()
         self.server_manager.add_route(
             "POST",

--- a/client/version_control/rest/perforce/rest_api.py
+++ b/client/version_control/rest/perforce/rest_api.py
@@ -105,6 +105,13 @@ class PerforceModuleRestAPI:
             submit_change_list.dispatch
         )
 
+        submit_default_changelist = rest_routes.SubmitDefaultChangelist()
+        self.server_manager.add_route(
+            "POST",
+            self.prefix + "/submit_default_changelist",
+            submit_default_changelist.dispatch
+        )
+
         exists_on_server = rest_routes.ExistsOnServer()
         self.server_manager.add_route(
             "POST",

--- a/client/version_control/rest/perforce/rest_api.py
+++ b/client/version_control/rest/perforce/rest_api.py
@@ -70,6 +70,13 @@ class PerforceModuleRestAPI:
             is_checkouted.dispatch
         )
 
+        revert = rest_routes.Revert()
+        self.server_manager.add_route(
+            "POST",
+            self.prefix + "/revert",
+            revert.dispatch
+        )
+
         get_changes = rest_routes.GetChanges()
         self.server_manager.add_route(
             "POST",

--- a/client/version_control/rest/perforce/rest_stub.py
+++ b/client/version_control/rest/perforce/rest_stub.py
@@ -106,6 +106,12 @@ class PerforceRestStub:
         return response
 
     @staticmethod
+    def submit_default_changelist(comment):
+        response = PerforceRestStub._wrap_call(
+            "submit_default_changelist", comment=comment)
+        return response
+
+    @staticmethod
     def revert(path):
         response = PerforceRestStub._wrap_call(
             "revert", path=path)

--- a/client/version_control/rest/perforce/rest_stub.py
+++ b/client/version_control/rest/perforce/rest_stub.py
@@ -94,6 +94,12 @@ class PerforceRestStub:
         return response
 
     @staticmethod
+    def get_uncommitted_changes():
+        # type: (None) -> dict
+        response = PerforceRestStub._wrap_call("get_uncommitted_changes")
+        return response
+
+    @staticmethod
     def submit_change_list(comment):
         response = PerforceRestStub._wrap_call(
             "submit_change_list", comment=comment)

--- a/client/version_control/rest/perforce/rest_stub.py
+++ b/client/version_control/rest/perforce/rest_stub.py
@@ -106,6 +106,12 @@ class PerforceRestStub:
         return response
 
     @staticmethod
+    def revert(path):
+        response = PerforceRestStub._wrap_call(
+            "revert", path=path)
+        return response
+
+    @staticmethod
     def exists_on_server(path):
         response = PerforceRestStub._wrap_call(
             "exists_on_server", path=path)


### PR DESCRIPTION
## Changelog Description
- adds `get_uncommitted_changes` endpoint
- adds validator that checks for any uncommitted changes in the user's p4 workspace
  - inits repair action with a little user UI

## ToDo's
- [x] implement p4 revert and submit endpoints for repair action